### PR TITLE
Create estimated-subsidence-minimum.yml

### DIFF
--- a/DSL/Ruuter.public/estonian-statistics/estimated-subsidence-minimum.yml
+++ b/DSL/Ruuter.public/estonian-statistics/estimated-subsidence-minimum.yml
@@ -1,0 +1,40 @@
+variables_step:
+  assign:
+    year: ${new Date().getFullYear().toString()}
+
+post_step:
+  call: http.post
+  args:
+    url: https://andmed.stat.ee/api/v1/et/stat/LE27
+    body:
+      query:
+        - code: "Näitaja"
+          selection:
+            filter: "item"
+            values:
+              - "1"
+        - code: "Aasta"
+          selection:
+            filter: "item"
+            values:
+              - ${year}
+      response:
+        format: "json-stat2"
+  result: subsidence
+  next: check_results
+
+check_results:
+  switch:
+    - condition: ${subsidence.response.body.value === undefined}
+      next: try_second_month_step
+    - condition: ${subsidence.response.body.value[0] != undefined}
+      next: success_step
+
+success_step:
+  return: ${"Viimati avaldas statistikaamet arvestusliku elatusmiinimumi 2022.a kohta ja see oli " + subsidence.response.body.value[0] + "."}
+  next: end
+
+try_second_month_step:
+  assign:
+    year: ${year - 1}
+  next: post_step


### PR DESCRIPTION
Issue: [#3](https://github.com/buerokratt/Common-Services/issues/3) 

Service for querying the estimated subsidence minimum number from Statistics Estonia.
Always makes a query for the current year or the closest possible year with available statistics. 

Requires the setting "stopInCaseOfException: false" in Ruuter's configuration so as to avoid a premature stop in the service process. This is necessary as because stat.ee returns 400 Bad Request for querying any statistics that are not yet created.