### PR TITLE
Create labour-market-headline-indicators.yml

### DIFF
--- a/DSL/Ruuter.public/estonian-statistics/labour-market-headline-indicators.yml
+++ b/DSL/Ruuter.public/estonian-statistics/labour-market-headline-indicators.yml
@@ -1,0 +1,68 @@
+variables_step:
+  assign:
+    year: ${new Date().getFullYear().toString()}
+    month: ${new Date().getMonth()}
+    divided: ${(month + 3) / 3}
+    quarter: ${String(divided)[0]}
+    year_quarter: ${year + "Q" + quarter}
+
+post_step:
+  call: http.post
+  args:
+    url: https://andmed.stat.ee/api/v1/et/stat/TT0151
+    body:
+      query:
+        - code: "Näitaja"
+          selection:
+            filter: "item"
+            values:
+              - "UNEMP_RATE"
+        - code: "Sugu"
+          selection:
+            filter: "item"
+            values:
+              - "T"
+        - code: "Vanuserühm"
+          selection:
+            filter: "item"
+            values:
+              - "Y15-74"
+        - code: "Vaatlusperiood"
+          selection:
+            filter: "item"
+            values:
+              - ${year_quarter}
+      response:
+        format: "json-stat2"
+  result: unemployment
+  next: check_results
+
+check_results:
+  switch:
+    - condition: ${unemployment.response.body.value[0] === undefined}
+      next: try_second_quarter_step
+    - condition: ${unemployment.response.body.value[0] != null}
+      next: return_step
+
+check_quarter_step:
+  switch:
+    - condition: ${quarter == 1}
+      next: last_year_step
+    - condition: ${quarter != 1}
+      next: subtraction_step
+
+last_year_step:
+    assign:
+        year: ${year - 1}
+        quarter: 4
+        year_quarter: ${year + "Q" + quarter}
+    next: post_step
+
+subtraction_step:
+    assign:
+        quarter: ${quarter - 1}
+        year_quarter: ${year + "Q" + quarter}
+    next: post_step
+
+return_step:
+   return: ${"Töötuse määr Eestis " + year + " " + quarter + ". kvartalis oli " + unemployment.response.body.value[0] + "%"}


### PR DESCRIPTION
Issue: [#6](https://github.com/buerokratt/Common-Services/issues/6)

Service for querying the labor marked headline indicator amount from Statistics Estonia.
This service first determines the current year and month, then calculates the appropriate number for the current quarter and makes a string in the style of "2023Q1" which is then sent as a necessary query value. If the statistics for the current quarter are not available, queries the last quarter. If the current quarter is Q1, decreases year by one and queries for Q4. 

Requires the setting "stopInCaseOfException: false" in Ruuter's configuration so as to avoid a premature stop in the service process. This is necessary as because stat.ee returns 400 Bad Request for querying any statistics that are not yet created.