### PR TITLE
Added get-elering-lowest-price.yml

### DIFF
--- a/DSL/Ruuter.public/elering/GET/get-elering-lowest-price.yml
+++ b/DSL/Ruuter.public/elering/GET/get-elering-lowest-price.yml
@@ -1,0 +1,32 @@
+getMessageDateTime:
+  call: http.get
+  args:
+    url: http://worldtimeapi.org/api/timezone/Europe/Tallinn
+  result: timeObject
+
+step_1:
+  assign:
+    dateTimeNow: ${timeObject.response.body.datetime}
+    tallinnOffset: ${(timeObject.response.body.dst_offset + timeObject.response.body.raw_offset)}
+    prevDate: ${new Date(new Date(dateTimeNow).getTime() - 24*60*60*1000).toISOString().substr(0, 10)}
+    date: ${dateTimeNow.substr(0, 10)}
+    startDateTime: ${prevDate + "T21:00:00.000Z"}
+    endDateTime: ${date + "T20:59:59.999Z"}
+
+getMessageElering:
+  call: http.get
+  args:
+    url: https://dashboard.elering.ee/api/nps/price
+    query:
+      start: ${startDateTime}
+      end: ${endDateTime}
+  result: eleringToday
+
+step_3:
+  assign:
+    minPrice: ${(eleringToday.response.body.data.ee.sort( (a,b) =>  a.price-b.price )[0]).price}
+    minPriceTimestamp: ${(eleringToday.response.body.data.ee.sort( (a,b) =>  a.price-b.price )[0]).timestamp + tallinnOffset}
+    timeVar: ${new Date(minPriceTimestamp * 1000).getHours() + ":00"}
+
+response:
+  return: ${"Täna on Nordpool elektribörsi odavaim hind kell " + timeVar + " ja selleks on " + minPrice}

--- a/DSL/Ruuter.public/elering/GET/get-elering-lowest-price.yml
+++ b/DSL/Ruuter.public/elering/GET/get-elering-lowest-price.yml
@@ -29,4 +29,4 @@ step_3:
     timeVar: ${new Date(minPriceTimestamp * 1000).getHours() + ":00"}
 
 response:
-  return: ${"Täna on Nordpool elektribörsi odavaim hind kell " + timeVar + " ja selleks on " + minPrice}
+  return: ${"Täna on Nordpool elektribörsi odavaim hind alates kell " + timeVar + " ja selleks on " + minPrice + " EUR/MWh."}


### PR DESCRIPTION
Issue #9 

Added a **get-elering-lowest-price.yml** file in the **DSL/Ruuter.public/elering/GET** path. 

This service enables the user to request today's lowest energy price for Estonia. The service first uses worldtimeapi.org api to get today's date and the timzone offset for Tallinn, which are then used for the request against elering energy price api. Then a sorting algorithm is used to get the cheapest energy price today and the time at that point, which is then converted to Tallinn local time.