### PR TITLE
Create population-metrics.yml

### DIFF
--- a/DSL/Ruuter.public/estonian-statistics/population-metrics.yml
+++ b/DSL/Ruuter.public/estonian-statistics/population-metrics.yml
@@ -1,0 +1,95 @@
+check_year_param:
+  switch:
+    - condition: ${incoming.params.year == null}
+      next: assign_default_year
+    - condition: ${incoming.params.year != null}
+      next: assign_param_year
+
+assign_default_year:
+  assign:
+    year: ${new Date().getFullYear().toString()}
+  next: check_location_param
+
+assign_param_year:
+  assign:
+    year: ${incoming.params.year}
+
+check_location_param:
+  switch:
+    - condition: ${incoming.params.location == null}
+      next: assign_default_location
+    - condition:  ${incoming.params.location != null}
+      next: assign_param_location
+
+assign_default_location:
+  assign:
+    location: "1"
+  next: get_stat
+
+assign_param_location:
+  assign:
+    location: ${incoming.params.location}
+    location_string: ${incoming.params.location}
+
+convert_location:
+  call: http.post
+  args:
+    url: "http://node:3000/hbs/statlocation"
+    body:
+      location: ${incoming.params.location}
+  result: location_conversion
+
+assign_location:
+  assign:
+    location: ${location_conversion.response.body}
+
+get_stat:
+  call: http.post
+  args:
+    url: "https://andmed.stat.ee/api/v1/et/stat/RV0291U"
+    body:
+      query:
+        - code: "Elukoht"
+          selection:
+            filter: "item"
+            values:
+              - ${location}
+        - code: "Aasta"
+          selection:
+            filter: "item"
+            values:
+              - ${year}
+        - code: "Näitaja"
+          selection:
+            filter: "item"
+            values:
+              - "1"
+      response:
+        format: json-stat2
+  result: result
+
+check_results:
+  switch:
+    - condition: ${result === undefined || result.response.body.value === undefined}
+      next: fail_step
+    - condition: ${location_string =! null || location_string != "null"}
+      next: location_string_step
+
+location_string_step:
+  assign:
+    location_string: ${location_string[1].toUpperCase() + location_string.slice(1)}
+
+location_return_success:
+  return: ${"Rahvaarv aastal " + year + " asukohas " + location_string + " oli " + result.response.body.value + "."}
+  next: end
+
+general_return_success:
+  return: ${"Rahvaarv aastal " + year + " üle kogu Eesti oli " + result.response.body.value + "."}
+  next: end
+
+fail_step:
+  assign:
+    result: undefined
+    location_string: null
+  return: null
+  status: 300


### PR DESCRIPTION
Service that fetches population statistics from Statistics Estonia by location and time (year) parameters. Service works with either parameter as well as both or none. 

- if no location parameter is given, fetches data for entirety of Estonia
- if no year parameter is given, fetches data for current year

If location parameter exists, the service first makes a query toward [Data Mapper](https://github.com/buerokratt/DataMapper) with the location string to fetch the appropriate stat number for the location. This number is needed for the query toward Statistics Estonia.

[Working version of the Data Mapper files & new endpoint](https://github.com/buerokratt/DataMapper/pull/14)

The Data Mapper query requires a POST endpoint with the return header of Content-Type: application/json. 

If the service fails in case of incorrect inputs or any other reason, returns the error code 300. 