### PR TITLE
added time-period service, mock and readme

### DIFF
--- a/DSL/Ruuter.public/electricity/mock/time-period.yml
+++ b/DSL/Ruuter.public/electricity/mock/time-period.yml
@@ -1,0 +1,94 @@
+declaration:
+  call: declare
+  version: 0.1
+  name: "MOCK - Electricity Price Service"
+  description: |
+    This service fetches the Nordpool electricity prices for a user-specified date.
+  method: get
+  params:
+    userTime: string  # yyyy-mm-dd format
+  returns: json
+
+# Prepare Dates based on userTime
+prepareDates:
+  assign:
+    userTime: ${incoming.params.userTime || new Date().toISOString().split('T')[0]}  # yyyy-mm-dd 
+    startDateTime: ${new Date(new Date(userTime).getTime() - 24 * 60 * 60 * 1000).toISOString().split('T')[0] + "T21:00:00.000Z"} # day before at 9am
+    endDateTime: ${userTime + "T20:59:59.000Z"} # chosen date at 9pm - default time format
+  next: getPriceForPeriod
+
+getPriceForPeriod:
+  call: reflect.mock
+  args:
+    request:
+      url: https://dashboard.elering.ee/api/nps/price
+      query:
+        start: ${startDateTime}
+        end: ${endDateTime}
+    response:
+        data:
+          ee: # mock data
+            - timestamp: 1728507600
+              price: 6.9500
+            - timestamp: 1728511200
+              price: 58.6900
+            - timestamp: 1728514800
+              price: 45.6700
+            - timestamp: 1728518400
+              price: 24.9100
+            - timestamp: 1728522000
+              price: 12.8900
+            - timestamp: 1728525600
+              price: 14.2400
+            - timestamp: 1728529200
+              price: 38.8700
+            - timestamp: 1728532800
+              price: 61.6000
+            - timestamp: 1728536400
+              price: 86.7100
+            - timestamp: 1728540000
+              price: 80.4600
+            - timestamp: 1728543600
+              price: 67.5000
+            - timestamp: 1728547200
+              price: 24.9800
+            - timestamp: 1728550800
+              price: 24.7400
+            - timestamp: 1728554400
+              price: 21.8300
+            - timestamp: 1728558000
+              price: 15.9400
+            - timestamp: 1728561600
+              price: 19.7800
+            - timestamp: 1728565200
+              price: 20.1100
+            - timestamp: 1728568800
+              price: 17.9100
+            - timestamp: 1728572400
+              price: 70.0200
+            - timestamp: 1728576000
+              price: 70.0600
+            - timestamp: 1728579600
+              price: 27.0300
+            - timestamp: 1728583200
+              price: 6.1600
+            - timestamp: 1728586800
+              price: 3.3200
+            - timestamp: 1728590400
+              price: 0.0000
+  result: eleringToday
+  next: assignVariables
+
+assignVariables:
+  assign:
+    minPrice: ${eleringToday.response.body.data.ee.sort((a, b) => a.price - b.price)[0].price} # get lowest price
+    minPriceTimestamp: ${eleringToday.response.body.data.ee.sort((a, b) => a.price - b.price)[0].timestamp} # get lowest timestamp
+
+    tallinnOffset: 10800  # Tallinn is UTC+3 during DST (3 hours in seconds)
+    adjustedTimestamp: ${minPriceTimestamp + tallinnOffset} 
+    adjustedHour: ${Math.floor((adjustedTimestamp % 86400) / 3600)}
+    timeVar: ${("0" + adjustedHour).slice(-2) + ":00"}
+  next: returnResult
+
+returnResult:
+  return: ${[userTime, timeVar, minPrice]}

--- a/DSL/Ruuter.public/electricity/time-period.yml
+++ b/DSL/Ruuter.public/electricity/time-period.yml
@@ -1,0 +1,67 @@
+declaration:
+  call: declare
+  version: 0.2
+  name: "Electricity Price Service"
+  description: |
+    This service fetches Nordpool electricity prices for a specified date range.
+  method: get
+  params:
+    startDate: string  # yyyy-mm-dd format (start of the period)
+    endDate: string    # yyyy-mm-dd format (end of the period)
+  returns: json
+
+# Prepare startDate, endDate
+getDates:
+  assign:
+    startDate: ${incoming.params.startDate || new Date().toISOString().split('T')[0]}  # yyyy-mm-dd
+    endDate: ${incoming.params.endDate || new Date().toISOString().split('T')[0]} # default to today
+  next: formatDates
+
+# make dates conform to API standard
+formatDates:
+  assign:
+    startDateTime: ${new Date(new Date(startDate).getTime() - 24 * 60 * 60 * 1000).toISOString().split('T')[0] + "T21:00:00.000Z"}
+    endDateTime: ${endDate + "T20:59:59.000Z"}
+  next: dateCheck
+
+dateCheck:
+  switch:
+    - condition: ${new Date(endDateTime) < new Date(startDateTime)}
+      next: startDateError
+  next: logStep
+
+logStep:
+  log: "Start date: ${startDateTime}, End date: ${endDateTime}"
+  next: getPriceForPeriod
+
+getPriceForPeriod:
+  call: http.get
+  args:
+    url: https://dashboard.elering.ee/api/nps/price
+    query:
+      start: ${startDateTime}
+      end: ${endDateTime}
+  result: eleringPrices
+  next: assignResult
+
+assignResult:
+  assign:
+    periodPrices: ${eleringPrices.response.body.data.ee}
+    responseLength: ${(eleringPrices.response.body.data.ee).length}
+  next: logResult
+
+logResult:
+  log: "RESPONSE LENGTH: ${responseLength}"
+  next: returnResult
+
+returnResult:
+  return: ${periodPrices}
+  next: end
+
+startDateError:
+  return: "Error: start date cannot be later than end date"
+  next: end
+
+dateRangeError:
+  return: "Error: interval cannot be longer than 1 year"
+  next: end

--- a/docs/example-queries/electricity/README:md
+++ b/docs/example-queries/electricity/README:md
@@ -1,0 +1,47 @@
+# Electricity service API
+
+## Fetch the lowest or highest electricity price for a specific date (default is today)
+**Endpoints**
+```
+electricity/mock/lowest-price
+electricity/lowest-price
+electricity/mock/highest-price
+electricity/highest-price
+```
+
+**Sample query - without date**
+```
+curl localhost:8080/electricity/mock/lowest-price
+curl localhost:8080/electricity//lowest-price
+
+curl localhost:8080/electricity/mock/highest-price
+curl localhost:8080/electricity//highest-price
+```
+
+**Expected outcome**
+```
+{
+    "response": [
+        "2024-10-10",
+        "23:00",
+        0.0
+    ]
+}
+```
+
+**Sample query - with a specific date parameter (userDate)**
+```
+curl localhost:8080/electricity/mock/lowest-price?userDate=2024-05-05
+curl localhost:8080/electricity/lowest-price?userDate=2024-05-05
+```
+
+**Expected outcome**
+```
+{
+    "response": [
+        "2024-05-05",
+        "15:00",
+        1.9
+    ]
+}
+```


### PR DESCRIPTION
The End Client can specify the time period to get electricity information about [#87](https://github.com/buerokratt/Common-Services/issues/87)
